### PR TITLE
NEW: Update API call to V3, inject API key into request

### DIFF
--- a/_config/injector.yml
+++ b/_config/injector.yml
@@ -4,3 +4,6 @@ Name: HaveIBeenPwnedInjector
 SilverStripe\Core\Injector\Injector:
   SilverStripe\Security\MemberAuthenticator\LoginHandler:
     class: Firesphere\HaveIBeenPwned\Controllers\LoginHandler
+  Firesphere\HaveIBeenPwned\Services\HaveIBeenPwnedService:
+    properties:
+      hibp_api_key: '`HIBP_API_KEY`'

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,14 @@ PHP 5.6+
 
 # Configuration
 
+Making calls to the Have I Been Pwned API requires a key. There's [a full blog post on why here](https://www.troyhunt.com/authentication-and-the-have-i-been-pwned-api).
+
+To configure this module to use the key, define an environment variable on your server or your .env:
+
+```ini
+HIBP_API_KEY="deadbeeff33df00ddeadbeeff33df00d"
+```
+
 ```yaml
 
 ---

--- a/src/services/HaveIBeenPwnedService.php
+++ b/src/services/HaveIBeenPwnedService.php
@@ -21,7 +21,7 @@ class HaveIBeenPwnedService
     /**
      * Api endpoint emails
      */
-    const PWND_URL = 'https://haveibeenpwned.com/api/';
+    const PWND_URL = 'https://haveibeenpwned.com/api/v3/';
 
     /**
      * API endpoint passwords
@@ -31,7 +31,7 @@ class HaveIBeenPwnedService
     /**
      * API Version
      */
-    const API_VERSION = '2';
+    const API_VERSION = '3';
 
     /**
      * Useragent
@@ -72,7 +72,7 @@ class HaveIBeenPwnedService
     public function checkPwnedPassword($pwd)
     {
         $this->args['base_uri'] = static::PWND_API_URL;
-
+        $api_key = $this->hibp_api_key;
         $sha = sha1($pwd);
         $shaStart = substr($sha, 0, 5);
         $shaEnd = substr($sha, 5);
@@ -84,7 +84,8 @@ class HaveIBeenPwnedService
             [
                 'headers' => [
                     'user-agent'  => static::USER_AGENT,
-                    'api-version' => static::API_VERSION
+                    'api-version' => static::API_VERSION,
+                    'hibp-api-key' => $api_key
                 ]
             ]
         );
@@ -121,6 +122,7 @@ class HaveIBeenPwnedService
     public function checkPwnedEmail($member)
     {
         $this->args['base_uri'] = static::PWND_URL;
+        $api_key = $this->hibp_api_key;
         $uniqueField = Member::config()->get('unique_identifier_field');
         $account = $member->{$uniqueField};
 
@@ -133,7 +135,8 @@ class HaveIBeenPwnedService
             [
                 'headers' => [
                     'user-agent'  => static::USER_AGENT,
-                    'api-version' => static::API_VERSION
+                    'api-version' => static::API_VERSION,
+                    'hibp-api-key' => $api_key
                 ]
             ]
         );

--- a/tests/unit/LoginHandlerTest.php
+++ b/tests/unit/LoginHandlerTest.php
@@ -11,6 +11,7 @@ use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\Session;
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Environment;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Security\Authenticator;
@@ -119,12 +120,20 @@ class LoginHandlerTest extends SapphireTest
         $this->assertContains('You can read more here', $passwordForm->getMessage());
 
         // Default Admin is always allowed
-        $response = $this->handler->doLogin(['Email' => 'admin', 'Password' => 'password'], $form, $request);
+        $admin = Environment::getEnv('SS_DEFAULT_ADMIN_USERNAME');
+        $password = Environment::getEnv('SS_DEFAULT_ADMIN_PASSWORD');
 
-        $this->assertEquals(302, $response->getStatusCode());
-        $this->assertNotContains('lostpassword', $response->getHeader('location'));
-        $member = Security::getCurrentUser();
-        $this->assertTrue(DefaultAdminService::isDefaultAdmin($member->Email));
+        //don't run the test if default admin or password are missing
+        if (!$admin || !$password) {
+            $this->markTestSkipped();
+        } else {
+            $response = $this->handler->doLogin(['Email' => $admin, 'Password' => $password], $form, $request);
+
+            $this->assertEquals(302, $response->getStatusCode());
+            $this->assertNotContains('lostpassword', $response->getHeader('location'));
+            $member = Security::getCurrentUser();
+            $this->assertTrue(DefaultAdminService::isDefaultAdmin($member->Email));
+        }
     }
 
     protected function setUp()

--- a/tests/unit/MemberExtensionTest.php
+++ b/tests/unit/MemberExtensionTest.php
@@ -4,6 +4,7 @@ namespace Firesphere\HaveIBeenPwned\Tests;
 
 use Firesphere\HaveIBeenPwned\Extensions\MemberExtension;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\Debug;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\ReadonlyField;
@@ -22,8 +23,12 @@ class MemberExtensionTest extends SapphireTest
         $fields = $this->member->getCMSFields();
 
         $this->assertInstanceOf(ReadonlyField::class, $fields->dataFieldByName('PasswordIsPwnd'));
-        $this->assertNotContains('If the error says that you "have been Pwnd", ', $fields->forTemplate());
         $this->assertNull($fields->fieldByName('Root.HaveIBeenPwned'));
+        $this->assertNull(
+            $fields->findOrMakeTab('Root.HaveIBeenPwned')
+            ->Fields()
+            ->fieldByName('Helptext')
+        );
         $this->assertInstanceOf(CheckboxField::class, $fields->dataFieldByName('PwndDisabled'));
 
         $this->member->BreachedSites = '000error, test';
@@ -38,8 +43,22 @@ class MemberExtensionTest extends SapphireTest
         $this->assertInstanceOf(Tab::class, $fields->fieldByName('Root.HaveIBeenPwned'));
         $this->assertInstanceOf(ReadonlyField::class, $fields->dataFieldByName('BreachedSites'));
 
-        $this->assertContains('Known breaches', $fields->forTemplate());
-        $this->assertContains('If the error says that you "have been Pwnd", ', $fields->forTemplate());
+        $this->assertNotNull($fields->dataFieldByName('BreachedSites'));
+        $this->assertEquals('Known breaches', $fields->dataFieldByName('BreachedSites')->Title());
+
+        $this->assertNotNull(
+            $fields->findOrMakeTab('Root.HaveIBeenPwned')
+            ->Fields()
+            ->fieldByName('Helptext')
+        );
+
+        $this->assertContains(
+            'If the error says that you "have been Pwnd", ',
+            $fields->findOrMakeTab('Root.HaveIBeenPwned')
+            ->Fields()
+            ->fieldByName('Helptext')
+            ->getContent()
+        );
     }
 
     protected function setUp()


### PR DESCRIPTION
This should probably be considered a breaking change, since the old API doesn't work anymore and v3 requires a key.

The only other difference I could see is that a new email (or one that doesn't appear in a breach) will return a 404 response instead of a 200. I have account for this in the endpoint.

You'll need to define a new environment variable or key in your .env: `HIBP_API_KEY` after purchasing an API key to use it.

Also fixes unit tests:
* don't assume DefaultAdmin is set, or has a certain password
* testUpdateCMSField wasn't working with forTemplate()